### PR TITLE
support post redirects from IdP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.2
+
+**Release date:** 2022-07-07
+
+### Features
+* Support IdP which sends the redirect request via POST, transform request into GET with query strings
+
+
 ## 0.1.1
 
 **Release date:** 2022-06-15

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
 - deployment.yaml
 images:
 - name: ghcr.io/doodlescheduling/k8soauth2-proxy-controller
-  newTag: v0.1.1
+  newTag: v0.1.2


### PR DESCRIPTION
## Current situation
Apparently there are IdP which send the code back via a POST request.
The redirect proxy does not yet support this behavior.

## Proposal
This is difficult to support as we can't just proxy the request to the target because of cookie origin.
Meaning we still need to redirect the browser to the original origin which is only possible via GET.
What the proxy now does it extracts the code and state from the post form and adds it to the query string.

This only works if the proxied IdP also supports these inputs from the query string.
