### PR TITLE
fix: sign docker manifest

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,7 +92,7 @@ docker_signs:
   - cmd: cosign
     env:
     - COSIGN_EXPERIMENTAL=1
-    artifacts: images
+    artifacts: all
     output: true
     args:
     - 'sign'


### PR DESCRIPTION
 ## Current situation
Currently only the docker images are signed but not the manifest. Meaning: ``` cosign verify --certificate-identity-regexp=https://github.com/DoodleScheduling/k8sprom-patch-controller/.github/workflows/release.yaml@refs/tags/v0.2.1 --certificate-oidc-issuer=https://token.actions.githubusercontent.com ghcr.io/doodlescheduling/k8sprom-patch-controller:v0.2.1-amd64 ```
works while ``` cosign verify --certificate-identity-regexp=https://github.com/DoodleScheduling/k8sprom-patch-controller/.github/workflows/release.yaml@refs/tags/v0.2.1 --certificate-oidc-issuer=https://token.actions.githubusercontent.com ghcr.io/doodlescheduling/k8sprom-patch-controller:v0.2.1 ```
does not.
## Proposal
Sign both manifest and images.
